### PR TITLE
Regenerate secret if it starts with a '-'

### DIFF
--- a/hooks/postprovision-create-and-store-client-secret.ps1
+++ b/hooks/postprovision-create-and-store-client-secret.ps1
@@ -66,6 +66,7 @@ do {
         --id $ClientAppId `
         --display-name $SecretDisplayName `
         --query "password" `
+        --append `
         --output tsv
 
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
Retry secret generation if the secret starts with '-' as this can cause issues with Key Vault storage. See also https://github.com/Azure/azure-cli/issues/23016.