### PR TITLE
Verify credential creation before stopping hook

### DIFF
--- a/hooks/postprovision-create-and-store-client-certificate.ps1
+++ b/hooks/postprovision-create-and-store-client-certificate.ps1
@@ -78,7 +78,7 @@ Write-Host "Certificate created and added successfully"
 # Verify certificate exists in app registration
 # We retry a few times as there can be a delay before the certificate is visible in the app registration
 # If we don't do this, another hook might overwrite the credentials before they are actually registered
-Write-Host "Verifying certificate is registered in Entra ID..."
+Write-Host "Verifying certificate is registered in app registration..."
 $maxAttempts = 6
 $delay = 1
 

--- a/hooks/postprovision-create-and-store-client-secret.ps1
+++ b/hooks/postprovision-create-and-store-client-secret.ps1
@@ -99,7 +99,7 @@ Write-Host "Client secret stored successfully"
 # Verify secret exists in app registration
 # We retry a few times as there can be a delay before the secret is visible in the app registration
 # If we don't do this, another hook might overwrite the credentials before they are actually registered
-Write-Host "Verifying secret is registered in Entra ID..."
+Write-Host "Verifying secret is registered in app registration..."
 $maxAttempts = 6
 $delay = 1
 


### PR DESCRIPTION
Verify that certificate is registered on the app registration after creation. Do the same for the secret.

Fixes issue #7 