### PR TITLE
Add retries on deletion of service principals and app registrations

### DIFF
--- a/hooks/predown-remove-app-registrations.ps1
+++ b/hooks/predown-remove-app-registrations.ps1
@@ -90,7 +90,7 @@ if ($apps) {
             Write-Host "Verifying service principal $($sp.id) is in deleted items..."
             # Wait for the service principal to appear in deleted items
             Invoke-WithRetry -ScriptBlock {
-                az rest --method GET --url "https://graph.microsoft.com/beta/directory/deleteditems/$($sp.id)"
+                $deletedSp = az rest --method GET --url "https://graph.microsoft.com/beta/directory/deleteditems/$($sp.id)"
             }
             
             Write-Host "Permanently deleting service principal $($sp.id) of application with unique name $($app.uniqueName)"
@@ -112,7 +112,7 @@ if ($apps) {
         Write-Host "Verifying application $($app.id) is in deleted items..."
         # Wait for the application to appear in deleted items
         Invoke-WithRetry -ScriptBlock {
-            az rest --method GET --url "https://graph.microsoft.com/beta/directory/deleteditems/$($app.id)"
+            $deletedApp = az rest --method GET --url "https://graph.microsoft.com/beta/directory/deleteditems/$($app.id)"
         }
         
         Write-Host "Permanently deleting application $($app.id) with unique name $($app.uniqueName)"


### PR DESCRIPTION
Entra ID operations can be eventually consistent, leading to transient failures when trying to (permanently) delete a service principal or app registration. By adding retries, we make sure these resources are deleted.

Fixes issue #10 